### PR TITLE
fix syntax error in install script

### DIFF
--- a/scripts/install.js
+++ b/scripts/install.js
@@ -9,13 +9,13 @@ if (!gitPath) {
 }
 
 if (process.argv[2] == '--uninstall') {
-  const hooksFile = path.resolve(path.resolve(gitPath, 'hooks', 'post-commit'));
+  let hooksFile = path.resolve(path.resolve(gitPath, 'hooks', 'post-commit'));
   console.log('removing %s', hooksFile);
   fs.unlinkSync(hooksFile);
 } else {
   const hooksHeader = fs.readFileSync(path.resolve(__dirname, '../hooks/post-commit'), 'utf-8');
   const hooksSource = fs.readFileSync(path.resolve(__dirname, '../lib/index.js'), 'utf-8');
-  const hooksFile = path.resolve(gitPath, 'hooks', 'post-commit');
+  hooksFile = path.resolve(gitPath, 'hooks', 'post-commit');
   console.log('writing %s', hooksFile);
   fs.writeFileSync(hooksFile, hooksHeader + hooksSource, { mode: '0777' });
 }


### PR DESCRIPTION
`hooksFile` was declared as a `const` twice, throwing:

`SyntaxError: Identifier 'hooksFile' has already been declared`

PR uses `let` to fix this.